### PR TITLE
Gitlab Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `cargo-aur` Changelog
 
+## Unreleased
+
+#### Changed
+
+- `cargo aur` will now auto-detect the git host (Github or Gitlab) and generated
+  a `source` link based on that.
+
 ## 1.0.1 (2020-06-17)
 
 #### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 auto_from = "0.3"
+gumdrop = "0.8"
 hmac-sha256 = "0.1"
 itertools = "0.9"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 auto_from = "0.3"
-gumdrop = "0.8"
 hmac-sha256 = "0.1"
 itertools = "0.9"
 serde = "1.0"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ a PKGBUILD will be generated with all the necessary sections filled out.
 ## Installation
 
 Guess what? `cargo-aur` itself is on the AUR! Install it with an AUR-compatible
-package manager:
+package manager like [`aura`](https://github.com/fosskers/aura):
 
 ```
 sudo aura -A cargo-aur-bin
@@ -52,8 +52,8 @@ AUR standard.
 
 At this point, it is up to you to:
 
-1. Create an official `Release` on Github, attaching the original binary tarball
-   that `cargo aur` produced.
+1. Create an official `Release` on Github/Gitlab, attaching the original binary
+   tarball that `cargo aur` produced.
 2. Copy the PKGBUILD to a git repo that tracks releases of your package.
 3. Run `makepkg --printsrcinfo > .SRCINFO`.
 4. Commit both files and push to the AUR.


### PR DESCRIPTION
This PR extends `cargo aur` to auto-detect the Git host and generate `source` links based on that.