### PR TITLE
Added optional `depends` and `optdepends` keys

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,8 @@ struct Package {
     homepage: String,
     repository: String,
     license: String,
+    depends: Option<Vec<String>>,
+    optdepends: Option<Vec<String>>
 }
 
 impl Package {
@@ -174,6 +176,26 @@ fn pkgbuild<T: Write>(
         .unwrap_or(GitHost::Github)
         .source(package);
 
+    let depends = match &package.depends {
+        Some(dep) => dep
+                        .iter()
+                        .map(|a| format!("\"{}\"", a))
+                        .join(" "),
+        
+        None => String::from("")
+    };
+        
+   
+    
+    let optdepends = match &package.optdepends {
+        Some(dep) => dep
+                        .iter()
+                        .map(|a| format!("\"{}\"", a))
+                        .join(" "),
+        
+        None => String::from("")
+    };
+    
     writeln!(file, "{}", authors)?;
     writeln!(file, "#")?;
     writeln!(
@@ -190,6 +212,8 @@ fn pkgbuild<T: Write>(
     writeln!(file, "arch=(\"x86_64\")")?;
     writeln!(file, "provides=(\"{}\")", package.name)?;
     writeln!(file, "conflicts=(\"{}\")", package.name)?;
+    writeln!(file, "depends=({})", depends)?;
+    writeln!(file, "optdepends=({})", optdepends)?;
     writeln!(file, "source=(\"{}\")", source)?;
     writeln!(file, "sha256sums=(\"{}\")", sha256)?;
     writeln!(file)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,11 @@ struct Package {
     homepage: String,
     repository: String,
     license: String,
+    metadata: Option<Metadata>
+}
+
+#[derive(Deserialize, Debug)]
+struct Metadata {
     depends: Option<Vec<String>>,
     optdepends: Option<Vec<String>>
 }
@@ -176,24 +181,42 @@ fn pkgbuild<T: Write>(
         .unwrap_or(GitHost::Github)
         .source(package);
 
-    let depends = match &package.depends {
-        Some(dep) => dep
-                        .iter()
-                        .map(|a| format!("\"{}\"", a))
-                        .join(" "),
-        
-        None => String::from("")
-    };
-        
-   
+    // Handle optional table [package.metadata]
+    // They default to "" if the table is not present
+    let depends: String; 
+    let optdepends: String;
     
-    let optdepends = match &package.optdepends {
-        Some(dep) => dep
-                        .iter()
-                        .map(|a| format!("\"{}\"", a))
-                        .join(" "),
-        
-        None => String::from("")
+    match &package.metadata {
+        Some(metadata) => {  // If the table [package.metadata] is present
+
+            depends = match &metadata.depends {
+                // And depends is present
+                Some(dep) => dep
+                                .iter()
+                                .map(|a| format!("\"{}\"", a))
+                                .join(" "),
+
+                // Otherwise, set to default
+                None => String::from("")
+            };
+    
+            optdepends = match &metadata.optdepends {
+                // And optdepends is present
+                Some(dep) => dep
+                                .iter()
+                                .map(|a| format!("\"{}\"", a))
+                                .join(" "),
+                                
+                // Otherwise, set to default
+                None => String::from("")
+            };
+        },
+
+        // Otherwise, set to default
+        None => {
+            depends = String::from("");
+            optdepends = String::from("");
+        }
     };
     
     writeln!(file, "{}", authors)?;


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/7cQh7i97Cu3uPdbGfebjPPxnS.svg)](https://asciinema.org/a/7cQh7i97Cu3uPdbGfebjPPxnS)

## Why?
`depends` and `optdepends` are often needed when creating an AUR package. Not "cargo" dependencies, but other programs such as `mpv` to play videos.

## How?
This pull request adds two optional manifest keys: `depends` and `optdepends`, which are arrays of strings containing the name of the program's dependencies.

Since they are optional, this version will remain backwards-compatible. Empty arrays will be generated if not present in the Cargo.toml

## Possible improvements
- When compiling, cargo warns about "unused manifest keys" (because `depends` and `optdepends` are not valid cargo package keys). 
