### PR TITLE
Copying additional files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 - The `--output` flag for customizing the location of the output produced by
   `cargo aur`. If unused, the default remains `target/cargo-aur/`.
+- A new `files` field in `[package.metadata.aur]`, which accepts a list-of-pairs
+  of additional files you want copied to the user's filesystem upon package
+  installation. Output looks like:
+
+```
+package() {
+    install -Dm755 cargo-aur -t "$pkgdir/usr/bin"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 "/path/to/original" "/path/to/target"
+}
+```
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 package() {
     install -Dm755 cargo-aur -t "$pkgdir/usr/bin"
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-    install -Dm644 "/path/to/original" "/path/to/target"
+    install -Dm644 "/path/to/original/foo.txt" "$pkgdir/path/to/target/foo.txt"
 }
 ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ strip = true
 opt-level = "z"
 codegen-units = 1
 panic = "abort"
+
+[package.metadata.aur]
+depends = ["blah"]
+files = [["/path/to/original", "/path/to/target"]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ panic = "abort"
 
 [package.metadata.aur]
 # depends = ["blah"]
-# files = [[".github/dependabot.yml", "$pkgdir/usr/local/share/cargo-aur/dependabot.yml"]]
+# files = [[".github/dependabot.yml", "/usr/local/share/cargo-aur/dependabot.yml"]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ codegen-units = 1
 panic = "abort"
 
 [package.metadata.aur]
-depends = ["blah"]
-files = [["/path/to/original", "/path/to/target"]]
+# depends = ["blah"]
+# files = [[".github/dependabot.yml", "$pkgdir/usr/local/share/cargo-aur/dependabot.yml"]]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ filesystem. So this:
 
 ```toml
 [package.metadata.aur]
-files = [["path/to/local/foo.txt", "$pkgdir/usr/local/share/your-app/foo.txt"]]
+files = [["path/to/local/foo.txt", "/usr/local/share/your-app/foo.txt"]]
 ```
 
 will result in this:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ optdepends = ["sushi", "ramen"]
 
 And these settings will be copied to your PKGBUILD.
 
+### Including Additional Files
+
+The `files` list can be used to designated initial files to be copied the user's
+filesystem. So this:
+
+```toml
+[package.metadata.aur]
+files = [["path/to/local/foo.txt", "$pkgdir/usr/local/share/your-app/foo.txt"]]
+```
+
+will result in this:
+
+```toml
+package() {
+    install -Dm755 your-app -t "$pkgdir/usr/bin"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 "path/to/local/foo.txt" "$pkgdir/usr/local/share/your-app/foo.txt"
+}
+```
+
 ### Static Binaries
 
 Run with `--musl` to produce a release binary that is statically linked via

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Errors that can occur in this application.
 
-use std::fmt::Display;
+use std::{fmt::Display, path::PathBuf};
 
 pub(crate) enum Error {
     IO(std::io::Error),
@@ -9,6 +9,7 @@ pub(crate) enum Error {
     Utf8OsString,
     MissingMuslTarget,
     MissingLicense,
+    TargetNotAbsolute(PathBuf),
 }
 
 impl Display for Error {
@@ -24,6 +25,9 @@ impl Display for Error {
             ),
             Error::MissingLicense => {
                 write!(f, "Missing LICENSE file. See https://choosealicense.com/")
+            }
+            Error::TargetNotAbsolute(p) => {
+                write!(f, "Target filepath is not absolute: {}", p.display())
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,18 @@ pub struct Metadata {
     pub aur: Option<AUR>,
 }
 
+impl Metadata {
+    /// The metadata block actually has some contents.
+    pub fn non_empty(&self) -> bool {
+        self.depends.is_empty().not()
+            || self.optdepends.is_empty().not()
+            || self
+                .aur
+                .as_ref()
+                .is_some_and(|aur| aur.depends.is_empty().not() || aur.optdepends.is_empty().not())
+    }
+}
+
 impl std::fmt::Display for Metadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Reconcile which section to read extra dependency information from.
@@ -150,4 +162,6 @@ pub struct AUR {
     depends: Vec<String>,
     #[serde(default)]
     optdepends: Vec<String>,
+    #[serde(default)]
+    pub files: Vec<(String, String)>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,5 +163,5 @@ pub struct AUR {
     #[serde(default)]
     optdepends: Vec<String>,
     #[serde(default)]
-    pub files: Vec<(String, String)>,
+    pub files: Vec<(PathBuf, PathBuf)>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,16 @@ where
 
     if let Some(aur) = package.metadata.as_ref().and_then(|m| m.aur.as_ref()) {
         for (source, target) in aur.files.iter() {
-            writeln!(file, "    install -Dm644 \"{}\" \"{}\"", source, target)?;
+            if target.has_root().not() {
+                return Err(Error::TargetNotAbsolute(target.to_path_buf()));
+            } else {
+                writeln!(
+                    file,
+                    "    install -Dm644 \"{}\" \"$pkgdir{}\"",
+                    source.display(),
+                    target.display()
+                )?;
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,8 +208,11 @@ where
     writeln!(file, "provides=(\"{}\")", package.name)?;
     writeln!(file, "conflicts=(\"{}\")", package.name)?;
 
-    if let Some(metadata) = package.metadata.as_ref() {
-        writeln!(file, "{}", metadata)?;
+    match package.metadata.as_ref() {
+        Some(metadata) if metadata.non_empty() => {
+            writeln!(file, "{}", metadata)?;
+        }
+        Some(_) | None => {}
     }
 
     writeln!(file, "source=(\"{}\")", source)?;
@@ -232,6 +235,12 @@ where
             "    install -Dm644 {} \"$pkgdir/usr/share/licenses/$pkgname/{}\"",
             file_name, file_name
         )?;
+    }
+
+    if let Some(aur) = package.metadata.as_ref().and_then(|m| m.aur.as_ref()) {
+        for (source, target) in aur.files.iter() {
+            writeln!(file, "    install -Dm644 \"{}\" \"{}\"", source, target)?;
+        }
     }
 
     writeln!(file, "}}")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,17 @@ fn tarball(
     if let Some(lic) = license {
         command.arg(lic.path());
     }
+    if let Some(files) = config
+        .package
+        .metadata
+        .as_ref()
+        .and_then(|m| m.aur.as_ref())
+        .map(|a| a.files.as_slice())
+    {
+        for (file, _) in files {
+            command.arg(file);
+        }
+    }
     command.status()?;
 
     std::fs::remove_file(binary_name)?;


### PR DESCRIPTION
This PR enables the specification of a `files` list to designated extra files to be copied to the user's filesystem upon package installation.

Implements #19 