### PR TITLE
feat: inject custom commands into `package()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `cargo-aur` Changelog
 
+## Unreleased
+
+#### Added
+
+- A new `custom` field in `[package.metadata.aur]` which accepts a list of
+  strings that will be added as-is to the `package()` function of the PKGBUILD.
+  This allows the user to add specific extra commands to their build process.
+  See the README for more details.
+
 ## 1.7.1 (2024-03-18)
 
 #### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ panic = "abort"
 [package.metadata.aur]
 # depends = ["blah"]
 # files = [[".github/dependabot.yml", "/usr/local/share/cargo-aur/dependabot.yml"]]
+custom = ["echo hi"]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ package() {
 }
 ```
 
+### Custom commands within `package()`
+
+The `custom` list can be used to add specific commands to the `package()`
+function. This config:
+
+```toml
+[package.metadata.aur]
+custom = ["echo hi"]
+```
+
+yields:
+
+```
+package() {
+    install -Dm755 cargo-aur -t "$pkgdir/usr/bin"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    echo hi
+}
+```
+
+**Note:** Caveat emptor. No attempt is made to verify the injected commands.
+
 ### Static Binaries
 
 Run with `--musl` to produce a release binary that is statically linked via

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,4 +164,6 @@ pub struct AUR {
     optdepends: Vec<String>,
     #[serde(default)]
     pub files: Vec<(PathBuf, PathBuf)>,
+    #[serde(default)]
+    pub custom: Vec<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,6 +253,10 @@ where
                 )?;
             }
         }
+
+        for custom in aur.custom.iter() {
+            writeln!(file, "    {}", custom)?;
+        }
     }
 
     writeln!(file, "}}")?;


### PR DESCRIPTION
This PR allows custom commands to be injected into `package()`.