### PR TITLE
Upgrade to clap for argument parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["cargo", "subcommand", "archlinux", "aur"]
 categories = ["command-line-utilities"]
 
 [dependencies]
+clap = { version = "4.5.13", features = ["derive"] }
 colored = "2.0"
-gumdrop = "0.8"
 hmac-sha256 = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"


### PR DESCRIPTION
As mentioned on #28, command line arguments could use an overhaul, so kicking it off with an upgrade to `clap` since `gumdrop` seems to be no longer maintained.

I set this up to break as little as possible existing behaviour, if we are willing to change the version flag to clap default `-V` from `-v` it removes the need to have a version arg also.

Output of `cargo-aur --help` - Old
```
Usage: /home/nickd/.cargo/bin/cargo-aur [OPTIONS]

Positional arguments:
  free                 Absorbs any extra junk arguments.

Optional arguments:
  -h, --help           Display this help message.
  -v, --version        Display the current version of this software.
  -o, --output OUTPUT  Set a custom output directory (default: target/).
  -m, --musl           Use the MUSL build target to produce a static binary.
  -d, --dryrun         Don't actually build anything.
```

Output of `cargo-aur --help` - New
```
Prepare Rust projects to be released on the Arch Linux User Repository.

Usage: cargo-aur [OPTIONS]

Options:
  -o, --output <OUTPUT>  Set a custom output directory (default: target/)
  -m, --musl             Use the MUSL build target to produce a static binary
  -d, --dryrun           Don't actually build anything
  -v, --version          Print version
  -h, --help             Print help

```