### PR TITLE
feat: support `backup` packaging function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ package() {
 }
 ```
 
+### `backup`
+
+The `backup` list can be used to define files that may contain user-made changes that should be preserved if the package is removed or upgraded. File paths should not contain a leading slash. So this config:
+
+```toml
+[package.metadata.aur]
+backup = ["etc/your-app/foo.txt", "etc/your-app/bar.txt"]
+```
+
+will result in this:
+
+```
+backup=("etc/your-app/foo.txt", "etc/your-app/bar.txt")
+```
+
+If, for example, the `/etc/your-app/foo.txt` file is modified compared to the packaged file and the package is upgraded, the packaged file will be created as `/etc/your-app/foo.txt.pacnew` and not override the file which contains user-made changes.
+
 ### Custom commands within `package()`
 
 The `custom` list can be used to add specific commands to the `package()`
@@ -137,7 +154,7 @@ Run with `--musl` to produce a release binary that is statically linked via
     not a dynamic executable
 ```
 
-[0]: https://rust-lang.github.io/api-guidelines/documentation.html#c-metadata 
+[0]: https://rust-lang.github.io/api-guidelines/documentation.html#c-metadata
 [1]: https://github.com/fosskers/aura
 [2]: https://musl.libc.org/
 [3]: https://github.com/fosskers/cargo-aur/actions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,8 @@ pub struct AUR {
     #[serde(default)]
     optdepends: Vec<String>,
     #[serde(default)]
+    pub backup: Vec<String>,
+    #[serde(default)]
     pub files: Vec<(PathBuf, PathBuf)>,
     #[serde(default)]
     pub custom: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,20 @@ where
 
     writeln!(file, "source=(\"{}\")", source)?;
     writeln!(file, "sha256sums=(\"{}\")", sha256)?;
+
+    // Handle non-package() package.metadata.
+    if let Some(aur) = package.metadata.as_ref().and_then(|m| m.aur.as_ref()) {
+        let backup = aur
+            .backup
+            .iter()
+            .map(|b| format!("\"{}\"", b))
+            .collect::<Vec<_>>()
+            .join(", ");
+        if !backup.is_empty() {
+            writeln!(file, "backup=({})", backup)?;
+        };
+    }
+
     writeln!(file)?;
     writeln!(file, "package() {{")?;
     writeln!(
@@ -240,6 +254,7 @@ where
         )?;
     }
 
+    // Handle package() package.metadata.
     if let Some(aur) = package.metadata.as_ref().and_then(|m| m.aur.as_ref()) {
         for (source, target) in aur.files.iter() {
             if target.has_root().not() {


### PR DESCRIPTION
This PR adds support for the [`backup`](https://wiki.archlinux.org/title/PKGBUILD#backup) packaging function.

**rationale** 

Additional files can be included, which may be user-modified configuration files. As-is, a package build using `cargo-aur` will overwrite any user-made changes to files that are contained in the package. 

With this feature, files can be defined which may be user-modified. If a file is user-modified, the packaged file will be added as [.pacnew](https://wiki.archlinux.org/title/Pacman/Pacnew_and_Pacsave#.pacnew) and not overwrite any changes made by the user.

If a package is removed, and any packaged file is user-modified, a [.pacsave file](https://wiki.archlinux.org/title/Pacman/Pacnew_and_Pacsave#.pacsave) will be retained.

**implementation**

I extended the existing `[package.metadata.aur]` approach as to not get in the way of Cargo's default `[package]` and took a similar approach as to how the `package()` section is built up. This does duplicate that logic somewhat, but I suspect there may be other package functions that could piggy back of this approach in the future should there be a need for them.

I added relevant information in terms of usage in the README.