### PR TITLE
feature(metadata): get correct target dir when in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ gumdrop = "0.8"
 hmac-sha256 = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
+cargo_metadata = "0.19"
 
 [profile.release]
 lto = true

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub(crate) enum Error {
     MissingMuslTarget,
     MissingLicense,
     TargetNotAbsolute(PathBuf),
+    Metadata(cargo_metadata::Error),
 }
 
 impl Display for Error {
@@ -29,6 +30,9 @@ impl Display for Error {
             Error::TargetNotAbsolute(p) => {
                 write!(f, "Target filepath is not absolute: {}", p.display())
             }
+            Error::Metadata(m) => {
+                write!(f, "Failed to gather metadata: {}", m)
+            }
         }
     }
 }
@@ -36,6 +40,12 @@ impl Display for Error {
 impl From<std::str::Utf8Error> for Error {
     fn from(v: std::str::Utf8Error) -> Self {
         Self::Utf8(v)
+    }
+}
+
+impl From<cargo_metadata::Error> for Error {
+    fn from(v: cargo_metadata::Error) -> Self {
+        Self::Metadata(v)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod error;
 
 use crate::error::Error;
 use cargo_aur::{GitHost, Package};
+use cargo_metadata::MetadataCommand;
 use colored::*;
 use gumdrop::{Options, ParsingStyle};
 use hmac_sha256::Hash;
@@ -99,10 +100,8 @@ fn work(args: Args) -> Result<(), Error> {
     // Where cargo expects to read and write to. By default we want to read the
     // built binary from `target/release` and we want to write our results to
     // `target/cargo-aur`, but these are configurable by the user.
-    let cargo_target: PathBuf = match std::env::var_os("CARGO_TARGET_DIR") {
-        Some(p) => PathBuf::from(p),
-        None => PathBuf::from("target"),
-    };
+    let metadata = MetadataCommand::new().exec()?;
+    let cargo_target: PathBuf = metadata.target_directory.canonicalize()?;
 
     let output = args.output.unwrap_or(cargo_target.join("cargo-aur"));
 


### PR DESCRIPTION
Using cargo_metadata, will resolve the target directory better, when in a workspace or using custom configuruations otherwise for the package.